### PR TITLE
请升级cn.hutool:hutool-all组件版本以解决4个安全漏洞

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,7 @@
         <dependency>
             <groupId>cn.hutool</groupId>
             <artifactId>hutool-all</artifactId>
-            <version>5.7.7</version>
-        </dependency>
+            <version>5.8.19</version>        </dependency>
 
         <!--jwt依赖-->
         <dependency>


### PR DESCRIPTION
将 **cn.hutool:hutool-all** 组件从5.7.7 版本升级至 5.8.19版本,
用于修复以下安全漏洞：


序号 | 漏洞编号 | 漏洞标题 | 漏洞级别
-- | -- | -- | --
1 | [MPS-2023-2460](https://www.oscs1024.com/hd/MPS-2023-2460) | hutool 存在反序列化漏洞 | 高危
2 | [MPS-jdrq-1ywv](https://www.oscs1024.com/hd/MPS-jdrq-1ywv) | hutool <=5.8.17 存在SPEL命令执行风险 | 高危
3 | [MPS-2023-2459](https://www.oscs1024.com/hd/MPS-2023-2459) | hutool 表达式注入漏洞 | 严重
4 | [MPS-4soz-eyma](https://www.oscs1024.com/hd/MPS-4soz-eyma) | Hutool createTempFile函数敏感信息泄漏漏洞 | 中危
  |   |   |   


<br/>

_注意 ：此 PR 由您（或拥有此仓库权限的其他维护者）授权 [墨菲安全](https://www.murphysec.com) 打开_

了解更多：
- [如何快速修复代码安全问题](https://www.murphysec.com/docs/faqs/security-issues/how-to-quick-fixes.html)
